### PR TITLE
Created the error interface and also changed the logs to be json

### DIFF
--- a/baseftrwapp/baseftapp.go
+++ b/baseftrwapp/baseftapp.go
@@ -38,8 +38,8 @@ func RunServer(engs map[string]Service, healthHandler func(http.ResponseWriter, 
 	if env != "local" {
 		f, err := os.OpenFile("/var/log/apps/"+serviceName+"-go-app.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 		if err == nil {
-			log.SetFormatter(&log.TextFormatter{})
 			log.SetOutput(f)
+			log.SetFormatter(&log.TextFormatter{})
 		} else {
 			log.Fatalf("Failed to initialise log file, %v", err)
 		}

--- a/baseftrwapp/errors.go
+++ b/baseftrwapp/errors.go
@@ -1,0 +1,6 @@
+package baseftrwapp
+
+// InvalidRequestError for if a bad request has been issued to a method
+type InvalidRequestError interface {
+	InvalidRequestDetails() string
+}

--- a/baseftrwapp/errors.go
+++ b/baseftrwapp/errors.go
@@ -1,6 +1,6 @@
 package baseftrwapp
 
 // InvalidRequestError for if a bad request has been issued to a method
-type InvalidRequestError interface {
+type invalidRequestError interface {
 	InvalidRequestDetails() string
 }

--- a/baseftrwapp/http_handlers.go
+++ b/baseftrwapp/http_handlers.go
@@ -22,8 +22,6 @@ func (hh *httpHandlers) putHandler(w http.ResponseWriter, req *http.Request) {
 	dec := json.NewDecoder(req.Body)
 	inst, docUUID, err := hh.s.DecodeJSON(dec)
 
-	fmt.Printf("ERROR: %s and OBJECT:%v", err, inst)
-
 	if err != nil {
 		log.Errorf("Error on parse=%v\n", err)
 		writeJsonError(w, err.Error(), http.StatusBadRequest)
@@ -38,7 +36,7 @@ func (hh *httpHandlers) putHandler(w http.ResponseWriter, req *http.Request) {
 	err = hh.s.Write(inst)
 	if err != nil {
 		switch e := err.(type) {
-		case InvalidRequestError:
+		case invalidRequestError:
 			log.Errorf("InvalidRequestError on write = %v\n", e.InvalidRequestDetails())
 			writeJsonError(w, e.InvalidRequestDetails(), http.StatusBadRequest)
 			return

--- a/baseftrwapp/http_handlers.go
+++ b/baseftrwapp/http_handlers.go
@@ -21,6 +21,9 @@ func (hh *httpHandlers) putHandler(w http.ResponseWriter, req *http.Request) {
 
 	dec := json.NewDecoder(req.Body)
 	inst, docUUID, err := hh.s.DecodeJSON(dec)
+
+	fmt.Printf("ERROR: %s and OBJECT:%v", err, inst)
+
 	if err != nil {
 		log.Errorf("Error on parse=%v\n", err)
 		writeJsonError(w, err.Error(), http.StatusBadRequest)
@@ -34,9 +37,16 @@ func (hh *httpHandlers) putHandler(w http.ResponseWriter, req *http.Request) {
 
 	err = hh.s.Write(inst)
 	if err != nil {
-		log.Errorf("Error on write=%v\n", err)
-		writeJsonError(w, err.Error(), http.StatusServiceUnavailable)
-		return
+		switch e := err.(type) {
+		case InvalidRequestError:
+			log.Errorf("InvalidRequestError on write = %v\n", e.InvalidRequestDetails())
+			writeJsonError(w, e.InvalidRequestDetails(), http.StatusBadRequest)
+			return
+		default:
+			log.Errorf("Error on write=%v\n", err)
+			writeJsonError(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
 	}
 	//Not necessary for a 200 to be returned, but for PUT requests, if don't specify, don't see 200 status logged in request logs
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
So that we could have specific http errors returned by the http handler an error interface was added that means it is not a breaking change to be incorporated into existing apps. Also the logging was changed to JSON to be more splunk friendly