### PR TITLE
Use types from new shared API package

### DIFF
--- a/baseftrwapp/http_handlers.go
+++ b/baseftrwapp/http_handlers.go
@@ -10,12 +10,13 @@ import (
 	"io"
 
 	"github.com/Financial-Times/neo-utils-go/neoutils"
+	"github.com/Financial-Times/up-rw-app-api-go/rwapi"
 	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 )
 
 type httpHandlers struct {
-	s Service
+	s rwapi.Service
 }
 
 func (hh *httpHandlers) putHandler(w http.ResponseWriter, req *http.Request) {

--- a/baseftrwapp/service.go
+++ b/baseftrwapp/service.go
@@ -1,16 +1,7 @@
 package baseftrwapp
 
 import (
-	"encoding/json"
+	"github.com/Financial-Times/up-rw-app-api-go/rwapi"
 )
 
-// Service defines the functions any read-write application needs to implement
-type Service interface {
-	Write(thing interface{}) error
-	Read(uuid string) (thing interface{}, found bool, err error)
-	Delete(uuid string) (found bool, err error)
-	DecodeJSON(*json.Decoder) (thing interface{}, identity string, err error)
-	Count() (int, error)
-	Check() error
-	Initialise() error
-}
+type Service rwapi.Service


### PR DESCRIPTION
The definition of Service has now been split out into its own package,
to enable other code to depend on it without having to depend on the
whole of this (rather complex) package.

This is a step towards introducing an __ids endpoint