### PR TITLE
Enable __ids if backend service supports it

### DIFF
--- a/baseftrwapp/baseftapp.go
+++ b/baseftrwapp/baseftapp.go
@@ -70,6 +70,7 @@ func router(engs map[string]Service, healthHandler func(http.ResponseWriter, *ht
 	for path, eng := range engs {
 		handlers := httpHandlers{eng}
 		m.HandleFunc(fmt.Sprintf("/%s/__count", path), handlers.countHandler).Methods("GET")
+		m.HandleFunc(fmt.Sprintf("/%s/__ids", path), handlers.idsHandler).Methods("GET")
 		m.HandleFunc(fmt.Sprintf("/%s/{uuid}", path), handlers.getHandler).Methods("GET")
 		m.HandleFunc(fmt.Sprintf("/%s/{uuid}", path), handlers.putHandler).Methods("PUT")
 		m.HandleFunc(fmt.Sprintf("/%s/{uuid}", path), handlers.deleteHandler).Methods("DELETE")


### PR DESCRIPTION
This adds a __ids endpoint.  This will work only if implemented by the
Service being used. Otherwise we return HTTP 501 Not Implemented.