### PR TITLE
Handle rwapi.ConstraintOrTransactionError

### DIFF
--- a/baseftrwapp/http_handlers.go
+++ b/baseftrwapp/http_handlers.go
@@ -57,8 +57,13 @@ func (hh *httpHandlers) putHandler(w http.ResponseWriter, req *http.Request) {
 			writeJSONError(w, e.NoContentReturnedDetails(), http.StatusNoContent)
 			return
 		case *neoutils.ConstraintViolationError:
+			// TODO: remove neo specific error check once all apps are
+			// updated to use neoutils.Connect() because that maps errors
+			// to rwapi.ConstraintOrTransactionError
 			writeJSONError(w, e.Error(), http.StatusConflict)
 			return
+		case rwapi.ConstraintOrTransactionError:
+			writeJSONError(w, e.Error(), http.StatusConflict)
 		case invalidRequestError:
 			writeJSONError(w, e.InvalidRequestDetails(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
Upcoming changes to the CypherRunner used can return
rwapi.ConstraintOrTransactionError.  Ensure we handle this as a conflict
and don't simply fall back to a http 503.